### PR TITLE
Ensure right file paths in archive when deployment made from Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ module.exports   = function(S) {
     BbPromise    = require('bluebird'),
     Zip          = require('node-zip'),
     fs           = require('fs'),
-    fse          = require('fs-extra');
+    fse          = require('fs-extra'),
+    pathSepRe    = new RegExp(`\\${ path.sep }`, 'g');
 
   class ServerlessAWSOverrides extends S.classes.Plugin {
 
@@ -120,7 +121,7 @@ module.exports   = function(S) {
 
               // Exclude certain files
               if (name.indexOf('DS_Store') == -1) {
-                zip.file(name, fs.readFileSync(item.path), {
+                zip.file(name.replace(pathSepRe, "/"), fs.readFileSync(item.path), {
                   unixPermissions: permissions
                 });
               }


### PR DESCRIPTION
I observed that for deployments made on Windows, the result lambda package has following content:

![screen shot 2018-05-28 at 13 50 06](https://user-images.githubusercontent.com/122434/40613248-11e27148-627e-11e8-8259-18a1c6031e85.png)

So there's flat structure with back slashes in place of directory separators.

Interestingly it probably doesn't break lambda (somehow paths are resolved as expected).

Still to avoid confusion and eventual bugs. It's good to have that fixed.

I tested proposed patch on both Windows and macOS, and both things works as expected